### PR TITLE
feat: add ErrorResponse model in error_response-1.0.0.yaml file

### DIFF
--- a/error_response-1.0.0.yaml
+++ b/error_response-1.0.0.yaml
@@ -1,0 +1,18 @@
+ErrorResponse:
+  allOf:
+    - $ref: 'https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.1.yaml#/Problem'
+    - type: object
+      properties:
+        variables:
+          additionalProperties:
+            type: string
+          description: Values for the variables used in the translation defined by type parameter
+        code:
+          type: string
+          example: ValidationFailed
+          deprecated: true
+          description: For removal since 4.13.0
+        message:
+          type: string
+          deprecated: true
+          description: For removal since 4.13.0

--- a/error_response-1.0.0.yaml
+++ b/error_response-1.0.0.yaml
@@ -11,8 +11,8 @@ ErrorResponse:
           type: string
           example: ValidationFailed
           deprecated: true
-          description: For removal since 4.13.0
+          description: For removal since 4.16.0
         message:
           type: string
           deprecated: true
-          description: For removal since 4.13.0
+          description: For removal since 4.16.0


### PR DESCRIPTION
- Added a new ErrorResponse model which includes Problem object from Zalando's guidelines.
- Added variables, code, and message properties to the ErrorResponse model.
- Marked 'code' and 'message' properties as deprecated.
- Properties are set for removal in upcoming releases.